### PR TITLE
Fixed Kuri Camera Connection Bugs

### DIFF
--- a/kuri_camera/README.md
+++ b/kuri_camera/README.md
@@ -43,3 +43,7 @@ This package provides multiple nodes for working with Kuri's camera, depending o
 ## Notes
 - This package includes camera configuration parameters that work for our Kuri. We do not provide guarantees that the same calibration parameters will work for other Kuri's. If your camera work requires a perfectly calibrated camera, we recommend you follow [ROS's monocular camera calibration tutorial](http://wiki.ros.org/camera_calibration/Tutorials/MonocularCalibration) and replace the parameters in config/camera_Calibration_parameters.yaml.
 - Sometimes while making the package you will get a warning due to a cycle in the constraint graph. Ignore that -- the code compiles properly despite that.
+
+## Known Issues
+- When accepting a TCP connection, `uds_to_tcp.cpp` uses the blocking `tcp_acceptor.accept()` as opposed to the non-blocking `async_accept()`. As a result, if you terminate it while it is waiting for a TCP connection, it will have to escalate to a SIGTERM.
+- If you terminate `uds_to_tcp.cpp` while it is working (i.e., not while it is waiting for a TCP connection), the UDS socket's read_some throws an error. This is likely because the madmux-daemon closes before the `uds_to_tcp` node, so the UDS socket is no longer a valid source to read from. There does not seem to be a simple way to ensure the `uds_to_tcp` closes before the madmux-daemon, but maybe this error can be handled within a try-catch statement.

--- a/kuri_camera/config/tcp_params.yaml
+++ b/kuri_camera/config/tcp_params.yaml
@@ -1,2 +1,1 @@
-tcp_socket_hostname: cococutkuri.personalrobotics.cs.washington.edu
 tcp_socket_port: 1234

--- a/kuri_camera/include/h264_decoder.h
+++ b/kuri_camera/include/h264_decoder.h
@@ -46,7 +46,7 @@ class H264Decoder {
   // int findBeginningOfH264Message(int bytes_read);                                /* as we readBuffer, this function finds the beginning of H264 messages */
   void establishTCPConnection();                                                 /* keep retrying until it establishes a TCP connection */
   void deestablishTCPConnection();                                               /* close the socket and reset the io_service */
-  static void avframeToMat(const AVFrame * frame, cv::Mat& image);
+  static void avframeToMat(const AVFrame * frame, cv::Mat& image);               /* Convert the AV Frames to CV Matrices */
 
   AVCodec* codec;                                                                /* the AVCodec* which represents the H264 decoder */
   AVCodecContext* codec_context;                                                 /* the context; keeps generic state */
@@ -85,6 +85,7 @@ class H264Decoder {
   std::condition_variable tcp_connect_cvar;                                      /* used to synchronize the asynchronous tcp connection function with the timeout */
   std::mutex tcp_read_some_mutex;                                                /* mutex for tcp_read_some_cvar */
   std::condition_variable tcp_read_some_cvar;                                    /* used to synchronize the asynchronous tcp read_some function with the timeout */
+  int connection_sleep_time;                                                     /* if the connection fails, how long to sleep before trying again */
 };
 
 #endif

--- a/kuri_camera/launch/uds_to_tcp.launch
+++ b/kuri_camera/launch/uds_to_tcp.launch
@@ -2,6 +2,11 @@
 
   <rosparam file="$(find kuri_camera)/config/tcp_params.yaml" command="load"/>
 
-  <node pkg="kuri_camera" type="uds_to_tcp" name="uds_to_tcp" output="screen"/>
+  <include file="$(find madmux)/launch/madmux_daemon.launch"/>
+
+  <node pkg="kuri_camera" type="uds_to_tcp" name="uds_to_tcp" output="screen">
+    <!-- The number of seconds to sleep before retrying to connect to the madmux UDS stream. -->
+    <param name="sleep_secs" type="int" value="1"/>
+  </node>
 
 </launch>

--- a/kuri_camera/src/h264_decoder_node.cpp
+++ b/kuri_camera/src/h264_decoder_node.cpp
@@ -207,12 +207,8 @@ int main(int argc, char **argv) {
   H264Decoder* h264_decoder = new H264Decoder();
   H264DecoderNode* node = new H264DecoderNode(nh, h264_decoder);
 
-  std::string tcp_socket_hostname;
+  std::string tcp_socket_hostname = ros::master::getHost();
   int tcp_socket_port;
-  if (!nh.getParam("/tcp_socket_hostname", tcp_socket_hostname)) {
-    ROS_ERROR("No hostname set at param /tcp_socket_hostname . Exiting.");
-    return -1;
-  }
   if (!nh.getParam("/tcp_socket_port", tcp_socket_port)) {
     ROS_ERROR("No port set at param /tcp_socket_port . Exiting.");
     return -1;

--- a/kuri_camera/src/tcp_test_client.cpp
+++ b/kuri_camera/src/tcp_test_client.cpp
@@ -63,12 +63,8 @@ int main(int argc, char **arcv) {
   boost::asio::ip::tcp::socket socket(io_service);
   boost::asio::ip::tcp::resolver resolver(io_service);
 
-  std::string tcp_socket_hostname;
+  std::string tcp_socket_hostname = ros::master::getHost();
   int tcp_socket_port;
-  if (!nh.getParam("/tcp_socket_hostname", tcp_socket_hostname)) {
-    ROS_ERROR("No hostname set at param /tcp_socket_hostname . Exiting.");
-    return -1;
-  }
   if (!nh.getParam("/tcp_socket_port", tcp_socket_port)) {
     ROS_ERROR("No port set at param /tcp_socket_port . Exiting.");
     return -1;

--- a/kuri_launch/launch/kuri.launch
+++ b/kuri_launch/launch/kuri.launch
@@ -6,7 +6,6 @@
     <include file="$(find mobile_base_driver)/launch/kuri_drive.launch"/>
 
     <!-- Kuri's eye camera -->
-    <include file="$(find madmux)/launch/madmux_daemon.launch"/>
     <include file="$(find kuri_camera)/launch/uds_to_tcp.launch"/>
 
     <!-- Kuri's face recognition -->

--- a/kuri_teleop/README.md
+++ b/kuri_teleop/README.md
@@ -25,6 +25,7 @@ In some cases, one may want the joystick velocity commands to override commands 
 
 ## Notes
 - kuri_edu does have a [joystick_teleop node](https://github.com/MayfieldRoboticsPublic/kuri_edu/blob/master/kuri_edu/src/kuri_edu/joystick_teleop.py). However, that node must be run **on the Kuri** (since it sends commands directly to the mobile_base_driver), although the joystick likely has to be connected to a remote computer (due to the difficulty of pairing a joystick directly to the Kuri). On the other hand, our joystick_teleop node sends commands to the Kuri using ros messages, so both the joystick and the joystick_teleop code can be run on the remote computer. To avoid the complex setup in the kuri_edu joystick_teleop node, we do not include that node in this package.
+- ~~If the Kuri's head lags behind the body in RVIZ when the global frame is an odometry frame, you likely have to increase the publish rate of the robot_state_publisher. On the kuri, open `/opt/gizmo/share/mobile_base_driver/launch/includes/robot.launch.xml` and increase the publish rate (you may need root permissions to write to this file).~~ (This fix does not work. We have not yet found a fix).
 
 ## TODO
 - Convert the hardcoded values in `joystick_teleop.cpp`that users may want to change (such as head pan speech, head pan duration, controll loop hertz, etc.) to ros params.


### PR DESCRIPTION
Fixed h264_decoder's ability to reconnect when the internet connection is dropped (e.g. during long-term navigation in a building)
Used a sleep time to ensure that the madmux-daemon launches before uds_to_tcp
Rearranged nodes in launch files so all the camera nodes are launched from kuri_camera