### PR TITLE
Add gizmo_msgs

### DIFF
--- a/gizmo_msgs/CMakeLists.txt
+++ b/gizmo_msgs/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(gizmo_msgs)
+
+
+add_compile_options(-std=c++11)
+
+
+find_package(catkin REQUIRED
+        COMPONENTS
+        geometry_msgs
+        mayfield_msgs
+        message_generation
+        std_msgs
+        )
+
+add_message_files(
+        FILES
+        Command.msg
+)
+
+add_service_files(
+        FILES
+)
+
+generate_messages(
+        DEPENDENCIES
+        geometry_msgs
+        mayfield_msgs
+        std_msgs
+)
+
+catkin_package(
+        CATKIN_DEPENDS
+        std_msgs
+)
+
+include_directories(${catkin_INCLUDE_DIRS})

--- a/gizmo_msgs/CMakeLists.txt
+++ b/gizmo_msgs/CMakeLists.txt
@@ -7,30 +7,95 @@ add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED
         COMPONENTS
+        actionlib
+        actionlib_msgs
+        audio_msgs
         geometry_msgs
         mayfield_msgs
         message_generation
+        mobile_base_driver
+        nav_msgs
+        sensor_msgs
         std_msgs
         )
 
+add_action_files(
+        FILES
+        CalibrationPath.action
+        RecordBagfile.action
+)
+
 add_message_files(
         FILES
+        Action.msg
+        Asleep.msg
+        Awake.msg
+        Bumpers.msg
+        ChestLED.msg
+        ClientTouch.msg
+        ClientWaypoint.msg
         Command.msg
+        CompressedOccupancyGrid.msg
+        Connection.msg
+        Deaf.msg
+        Exchange.msg
+        Field.msg
+        FilteredBattery.msg
+        HeadPose.msg
+        MomentAction.msg
+        MomentActions.msg
+        MqttMessage.msg
+        NavigationFeedback.msg
+        NavigationGoal.msg
+        RomojiFeedback.msg
+        RomojiGoal.msg
+        SoundHoundCommand.msg
+        StringStamped.msg
+        VolumeButton.msg
+        Volume.msg
 )
 
 add_service_files(
         FILES
+        Deafen.srv
+        GetDirection.srv
+        GetField.srv
+        ListFields.srv
+        MqttStatus.srv
+        MqttSubscribe.srv
+        PhotoCapture.srv
+        RobotInfo.srv
+        RobotPose.srv
+        SetField.srv
+        SetNavMode.srv
+        Snooze.srv
+        Stat.srv
+        UploaderStatus.srv
+        WakeUp.srv
+
 )
 
 generate_messages(
         DEPENDENCIES
+        actionlib_msgs
+        audio_msgs
         geometry_msgs
         mayfield_msgs
+        mobile_base_driver
+        nav_msgs
+        sensor_msgs
         std_msgs
 )
 
 catkin_package(
         CATKIN_DEPENDS
+        actionlib_msgs
+        audio_msgs
+        geometry_msgs
+        nav_msgs
+        mayfield_msgs
+        mobile_base_driver
+        sensor_msgs
         std_msgs
 )
 

--- a/gizmo_msgs/README.md
+++ b/gizmo_msgs/README.md
@@ -1,0 +1,3 @@
+# gizmo_msgs
+
+Message types used for interacting with gizmo, the default behavior stack on the Kuri. Extracted from the robot.

--- a/gizmo_msgs/action/CalibrationPath.action
+++ b/gizmo_msgs/action/CalibrationPath.action
@@ -1,0 +1,11 @@
+
+---
+
+#result definition
+bool success
+string error
+
+---
+
+
+

--- a/gizmo_msgs/action/RecordBagfile.action
+++ b/gizmo_msgs/action/RecordBagfile.action
@@ -1,0 +1,5 @@
+# mode is 'mapping' or 'localization' or 'stopped'
+string mode
+---
+bool success
+---

--- a/gizmo_msgs/msg/Action.msg
+++ b/gizmo_msgs/msg/Action.msg
@@ -1,0 +1,3 @@
+# ROS message to broadcast the robot's current task and/or reaction
+string task
+string reaction

--- a/gizmo_msgs/msg/Awake.msg
+++ b/gizmo_msgs/msg/Awake.msg
@@ -1,0 +1,3 @@
+geometry_msgs/Vector3 direction
+uint16 relative_angle
+float32 score

--- a/gizmo_msgs/msg/Bumpers.msg
+++ b/gizmo_msgs/msg/Bumpers.msg
@@ -1,0 +1,2 @@
+Header header
+mobile_base_driver/Bumper[3] bumper

--- a/gizmo_msgs/msg/ChestLED.msg
+++ b/gizmo_msgs/msg/ChestLED.msg
@@ -1,0 +1,1 @@
+std_msgs/ColorRGBA[] array

--- a/gizmo_msgs/msg/ClientTouch.msg
+++ b/gizmo_msgs/msg/ClientTouch.msg
@@ -1,0 +1,3 @@
+string request_id
+float32 x
+float32 y

--- a/gizmo_msgs/msg/ClientWaypoint.msg
+++ b/gizmo_msgs/msg/ClientWaypoint.msg
@@ -1,0 +1,2 @@
+string request_id
+string waypoint_uuid

--- a/gizmo_msgs/msg/Command.msg
+++ b/gizmo_msgs/msg/Command.msg
@@ -1,0 +1,2 @@
+string name
+mayfield_msgs/KeyValue[] params

--- a/gizmo_msgs/msg/CompressedOccupancyGrid.msg
+++ b/gizmo_msgs/msg/CompressedOccupancyGrid.msg
@@ -1,0 +1,12 @@
+# This represents a 2-D grid map, in which each cell represents the probability of
+# occupancy.
+
+Header header
+
+#MetaData for the map
+nav_msgs/MapMetaData info
+
+# This data is a png8 image file as it appears on disk encoded as a base64 string.
+# When uncompressed the pixel array is in row-major order, starting with (0,0).
+# Currently, unknown is 205, free is 255, and occupied is 0.
+string data

--- a/gizmo_msgs/msg/Connection.msg
+++ b/gizmo_msgs/msg/Connection.msg
@@ -1,0 +1,3 @@
+bool is_connected
+string peer_id
+bool are_all_peers_gone

--- a/gizmo_msgs/msg/Exchange.msg
+++ b/gizmo_msgs/msg/Exchange.msg
@@ -1,0 +1,3 @@
+SoundHoundCommand[] commands
+string error
+string transcription

--- a/gizmo_msgs/msg/Field.msg
+++ b/gizmo_msgs/msg/Field.msg
@@ -1,0 +1,5 @@
+string name
+string type
+uint32 length
+string description
+string mode

--- a/gizmo_msgs/msg/FilteredBattery.msg
+++ b/gizmo_msgs/msg/FilteredBattery.msg
@@ -1,0 +1,3 @@
+uint8 rounded_pct
+bool dock_present
+bool is_charging

--- a/gizmo_msgs/msg/HeadPose.msg
+++ b/gizmo_msgs/msg/HeadPose.msg
@@ -1,0 +1,2 @@
+float32 pan
+float32 tilt

--- a/gizmo_msgs/msg/MomentAction.msg
+++ b/gizmo_msgs/msg/MomentAction.msg
@@ -1,0 +1,2 @@
+string event
+string uuid

--- a/gizmo_msgs/msg/MomentActions.msg
+++ b/gizmo_msgs/msg/MomentActions.msg
@@ -1,0 +1,1 @@
+MomentAction[] actions

--- a/gizmo_msgs/msg/MqttMessage.msg
+++ b/gizmo_msgs/msg/MqttMessage.msg
@@ -1,0 +1,2 @@
+string topic
+string payload

--- a/gizmo_msgs/msg/NavigationFeedback.msg
+++ b/gizmo_msgs/msg/NavigationFeedback.msg
@@ -1,0 +1,22 @@
+byte GO_TO_WAYPOINT=0
+byte DRIVE_TO_POINT_IN_IMAGE=1
+byte FOLLOW_ME=2
+
+byte NAV_SUCCESS=0
+byte NAV_PLANNING=1
+byte NAV_MOVING=2
+byte NAV_ERROR=3
+byte NAV_CANCELED=4
+
+# NAV_ status
+byte status
+# Type of navigation
+byte nav_type
+# Request ID if from client
+string request_id
+# error string if NAV_ERROR
+string error
+# waypoint UUID if GO_TO_WAYPOINT
+string waypoint_uuid
+# Goal pose
+geometry_msgs/Pose goal

--- a/gizmo_msgs/msg/NavigationGoal.msg
+++ b/gizmo_msgs/msg/NavigationGoal.msg
@@ -1,0 +1,15 @@
+# This is a message covering all types of navigation
+byte GO_TO_WAYPOINT=0
+byte DRIVE_TO_POINT_IN_IMAGE=1
+byte FOLLOW_ME=2
+
+# Type of navigation
+byte nav_type
+# Goal of navigation
+geometry_msgs/Pose pose
+# Waypoint UUID for GO_TO_WAYPOINT
+string waypoint_uuid
+# Head pose for GO_TO_WAYPOINT
+gizmo_msgs/HeadPose head_pose
+# Request ID (if from client)
+string request_id

--- a/gizmo_msgs/msg/RomojiFeedback.msg
+++ b/gizmo_msgs/msg/RomojiFeedback.msg
@@ -1,0 +1,2 @@
+string request_id
+string feedback

--- a/gizmo_msgs/msg/RomojiGoal.msg
+++ b/gizmo_msgs/msg/RomojiGoal.msg
@@ -1,0 +1,6 @@
+# Name of romoji to play
+string name
+# Whether to play sound or not (if the animation has sounds)
+bool sound
+# Request ID of the animation
+string request_id

--- a/gizmo_msgs/msg/SoundHoundCommand.msg
+++ b/gizmo_msgs/msg/SoundHoundCommand.msg
@@ -1,0 +1,2 @@
+string name
+mayfield_msgs/KeyValue[] params

--- a/gizmo_msgs/msg/StringStamped.msg
+++ b/gizmo_msgs/msg/StringStamped.msg
@@ -1,0 +1,3 @@
+Header header
+string timems
+string data

--- a/gizmo_msgs/msg/Volume.msg
+++ b/gizmo_msgs/msg/Volume.msg
@@ -1,0 +1,17 @@
+# Volume level
+# If is_relative is True, this adds to the current volume level
+# If is_relative is False, this sets the current volume level
+# Note: level is on the range [0:100], and will be clapmed appropriately
+# upon receipt of this message
+int16 level
+
+# Whether the level should be added to the current level or set absolutely
+bool is_relative
+
+# Mute and unmute
+# If either of these are set to true, the above values will not be used
+# Muting stores the volume level and sets the level to 0
+# Unmuting restores the volume level (or uses the default volume if no level
+# has been stored)
+bool mute
+bool unmute

--- a/gizmo_msgs/msg/VolumeButton.msg
+++ b/gizmo_msgs/msg/VolumeButton.msg
@@ -1,0 +1,2 @@
+bool up_button_pressed
+bool down_button_pressed

--- a/gizmo_msgs/package.xml
+++ b/gizmo_msgs/package.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<package>
+  <name>gizmo_msgs</name>
+  <version>14.3.1</version>
+  <description>The gizmo_msgs package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="sarah.osentoski@us.bosch.com">Sarah Osentoski</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://ros.org/wiki/robot2020_msgs</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>diagnostic_msgs</build_depend>
+  <build_depend>mobile_base_driver</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>mayfield_msgs</build_depend>
+
+  <run_depend>message_runtime</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>actionlib_msgs</run_depend>
+  <run_depend>nav_msgs</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>diagnostic_msgs</run_depend>
+  <run_depend>mobile_base_driver</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- You can specify that this package is a metapackage here: -->
+    <!-- <metapackage/> -->
+
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/gizmo_msgs/package.xml
+++ b/gizmo_msgs/package.xml
@@ -4,46 +4,16 @@
   <version>14.3.1</version>
   <description>The gizmo_msgs package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="sarah.osentoski@us.bosch.com">Sarah Osentoski</maintainer>
-
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>TODO</license>
 
 
-  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://ros.org/wiki/robot2020_msgs</url> -->
-
-
-  <!-- Author tags are optional, mutiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintianers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *_depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use run_depend for packages you need at runtime: -->
-  <!--   <run_depend>message_runtime</run_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>actionlib_msgs</build_depend>
+  <build_depend>audio_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>diagnostic_msgs</build_depend>
@@ -54,19 +24,15 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>actionlib_msgs</run_depend>
+  <run_depend>audio_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>diagnostic_msgs</run_depend>
   <run_depend>mobile_base_driver</run_depend>
+  <run_depend>mayfield_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
 
 
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- You can specify that this package is a metapackage here: -->
-    <!-- <metapackage/> -->
-
-    <!-- Other tools can request additional information be placed here -->
-
   </export>
 </package>

--- a/gizmo_msgs/srv/Deafen.srv
+++ b/gizmo_msgs/srv/Deafen.srv
@@ -1,0 +1,2 @@
+---
+string state

--- a/gizmo_msgs/srv/GetDirection.srv
+++ b/gizmo_msgs/srv/GetDirection.srv
@@ -1,0 +1,6 @@
+uint8 threshold
+uint16 ms_duration
+uint16 ms_delay
+---
+geometry_msgs/Vector3 direction
+uint16 relative_angle

--- a/gizmo_msgs/srv/GetField.srv
+++ b/gizmo_msgs/srv/GetField.srv
@@ -1,0 +1,3 @@
+string name
+---
+string json_value

--- a/gizmo_msgs/srv/ListFields.srv
+++ b/gizmo_msgs/srv/ListFields.srv
@@ -1,0 +1,2 @@
+---
+audio_msgs/Field[] fields

--- a/gizmo_msgs/srv/MqttStatus.srv
+++ b/gizmo_msgs/srv/MqttStatus.srv
@@ -1,0 +1,14 @@
+---
+# MQTT Node will assemble topic names for you based on the device, environment
+# robot_id, and the 'endpoint' which is specified when you publish the message
+# More info at:
+# https://github.com/mayfieldrobotics/kuri_project_management/tree/master/mqtt
+string device
+string environment
+string robot_id
+
+# In test environment, we let MQTT pick its own path for credentials so we
+# don't interfere with other MQTT nodes
+string alt_cred_path
+
+bool connected

--- a/gizmo_msgs/srv/MqttSubscribe.srv
+++ b/gizmo_msgs/srv/MqttSubscribe.srv
@@ -1,0 +1,3 @@
+string topic
+---
+bool success

--- a/gizmo_msgs/srv/PhotoCapture.srv
+++ b/gizmo_msgs/srv/PhotoCapture.srv
@@ -1,0 +1,2 @@
+---
+sensor_msgs/CompressedImage image

--- a/gizmo_msgs/srv/RobotInfo.srv
+++ b/gizmo_msgs/srv/RobotInfo.srv
@@ -1,0 +1,4 @@
+---
+uint16 client_interface_ver
+string robot_base_ver
+string gizmo_ver

--- a/gizmo_msgs/srv/RobotPose.srv
+++ b/gizmo_msgs/srv/RobotPose.srv
@@ -1,0 +1,2 @@
+---
+geometry_msgs/Pose pose

--- a/gizmo_msgs/srv/SetField.srv
+++ b/gizmo_msgs/srv/SetField.srv
@@ -1,0 +1,3 @@
+string name
+string json_value
+---

--- a/gizmo_msgs/srv/SetNavMode.srv
+++ b/gizmo_msgs/srv/SetNavMode.srv
@@ -1,0 +1,3 @@
+string mode
+---
+bool success

--- a/gizmo_msgs/srv/Snooze.srv
+++ b/gizmo_msgs/srv/Snooze.srv
@@ -1,0 +1,2 @@
+---
+string state

--- a/gizmo_msgs/srv/Stat.srv
+++ b/gizmo_msgs/srv/Stat.srv
@@ -1,0 +1,3 @@
+---
+string state
+string direction

--- a/gizmo_msgs/srv/UploaderStatus.srv
+++ b/gizmo_msgs/srv/UploaderStatus.srv
@@ -1,0 +1,5 @@
+---
+# In test environment, we let the cloud uploader pick its own path for the
+# uploader queue.  In normal operation this will point to
+# /mayfield/something/something
+string uploader_queue

--- a/gizmo_msgs/srv/WakeUp.srv
+++ b/gizmo_msgs/srv/WakeUp.srv
@@ -1,0 +1,2 @@
+---
+string state


### PR DESCRIPTION
These message definitions are used by gizmo, the default executive on Kuri. It's helpful to have them in your local workspace so you can send messages or call actions remotely.